### PR TITLE
Fix blank page caused by merge marker remnants

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,8 +59,6 @@
   }
   .grab{cursor:grab;user-select:none;font-weight:700;padding:6px 8px;background:#1b1b1b;border-radius:8px}
   .dragging{opacity:.6}
-  .preview{width:60px;height:60px;object-fit:cover;display:none;border-radius:6px}
-=======
   .preview{width:60px;height:40px;object-fit:cover;display:none;border-radius:6px}
 
   .u{width:100%}
@@ -401,8 +399,6 @@ https://example.com/b.gif {&quot;seconds&quot;:45}"></textarea>
 
 
       urlInput.addEventListener("input", refreshPreview);
-      urlInput.addEventListener("change", ()=>{
-=======
       urlInput.addEventListener("change", ()=>{
         refreshPreview();
         if (li === selectedLi){ loadInspectorFromLi(li); if(editMode) maybePreviewSelected(); }


### PR DESCRIPTION
## Summary
- Remove leftover merge conflict markers from index.html
- Restore preview styles and input handlers so slideshow loads correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b022c1448321af755e3d69e147ef